### PR TITLE
slightly increase TIMEOUT

### DIFF
--- a/scripts/check_lsync_runs.bash
+++ b/scripts/check_lsync_runs.bash
@@ -4,7 +4,7 @@
 set -ue
 
 RUN_DIR=${1?'please provide base run dir'}
-TIMEOUT=${2-10000}
+TIMEOUT=${2-10800}
 EMAIL=${3-clinical-demux@scilifelab.se}
 # Default timeout is set to 2h30m (10000) as this is the time
 # between reading index and read2 for an X-run where there is no data.


### PR DESCRIPTION
New 2500 NIPT trigger a `hasta.scilifelab.se:/home/proj/production/flowcells/2500/runs//210413_D00415_0923_BHKNTYBCX3 is not syncing anymore!` email, it seems it takes a bit more time for the data to appear on hasta. Let's see if this solves the issue.


- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
